### PR TITLE
新規投稿機能の作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -55,3 +55,4 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'sorcery'
 gem 'oauth2'
 gem 'jwt'
+gem 'yt', '~> 0.32.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    yt (0.32.6)
+      activesupport
     zeitwerk (2.6.0)
 
 PLATFORMS
@@ -252,6 +254,7 @@ DEPENDENCIES
   tzinfo-data
   web-console (>= 4.1.0)
   webpacker (~> 5.0)
+  yt (~> 0.32.0)
 
 RUBY VERSION
    ruby 3.1.2p20

--- a/app/controllers/api/videos_controller.rb
+++ b/app/controllers/api/videos_controller.rb
@@ -1,7 +1,57 @@
 class Api::VideosController < ApplicationController
+  GOOGLE_API_KEY = ENV['GOOGLE_API_KEY']
+
+  def set_yt
+    Yt.configure do |config|
+      config.api_key = GOOGLE_API_KEY
+      config.log_level = :debug
+    end
+  end
 
   def index
     @videos = Video.includes(:user, :outputs)
     render :index, formats: :json, handlers: 'jbuilder'
   end
+
+  def create
+    youtube_url = video_params[:youtube_url]
+    if youtube_url[0..16] == "https://youtu.be/"
+      youtube_id = youtube_url[17..27]
+    else
+      youtube_id = youtube_url[32..42]
+    end
+
+    set_yt
+    yt_video = Yt::Video.new id: youtube_id
+    @video = current_user.videos.build
+    @video.youtube_id = video_params[:youtube_url]
+    @video.title = yt_video.title
+    @video.view_count = yt_video.view_count
+    @video.published_at = yt_video.published_at
+    @video.thumbnail = yt_video.thumbnail_url(size = :high)
+    if @video.save
+      @output = current_user.outputs.build(output_params)
+      @output.video_id = @video.id
+    else
+      render json: @video.errors, status: :bad_request
+    end
+
+    if @output.save
+      render json: [@video,@output], status: :ok
+    else
+      render json: @video.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def video_params
+    params.permit(:youtube_url)
+  end
+
+  def output_params
+    params.require(:output).permit(:summary, :impression)
+  end
+
+
 end

--- a/app/javascript/pages/video/create.vue
+++ b/app/javascript/pages/video/create.vue
@@ -1,12 +1,11 @@
 <template>
   <v-container class="mt-5 shades white rounded-lg mb-5">
     <p class="text-h4 pt-5 title font-weight-bold text-center">アウトプット投稿</p>
-      <form @submit.prevent="submit">
 
           <v-text-field
             v-model="youtube_url"
             label="YouTube動画URL"
-            placeholder="共有URLを貼り付けてください"
+            placeholder="YouTube動画URLを貼り付けてください"
             outlined
           ></v-text-field>
 
@@ -41,10 +40,10 @@
           class="mr-4 font-weight-bold"
           type="submit"
           color="success"
+          v-on:click="createVideo"
         >
           投稿する
         </v-btn>
-      </form>
   </v-container>
 </template>
 
@@ -59,7 +58,18 @@ export default {
         impression: ''
       }
     }),
+    methods: {
+      createVideo() {
+      this.$axios.post('videos', { youtube_url: this.youtube_url, output: this.output })
+        .then(res => {
+          this.$router.push({ name:'VideoIndex' })
+        })
+        .catch(err => {
+          console.log(err)
+        })
+    }
   }
+}
 </script>
 
 <style scoped>

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -34,7 +34,7 @@ const router = new Router({
       name: "VideoIndex",
     },
     {
-      path: "/video/new",
+      path: "/videonew",
       component: VideoCreate,
       name: "VideoCreate",
       meta: { requiredAuth: true },


### PR DESCRIPTION
## 概要

* video/create.vueで投稿ボタンからyouube_urlとoutputのsummary,impressionのparamsを送信する
* youtube_idから各種情報を取得するためyt_gemを導入
* YoutubeDataAPIのKEYを取得
* API_KEYの環境設定
* videosコントローラーのcreateアクションの実装

## 確認方法

* 新規投稿ページからYoutubeのURLとアウトプット内容を入力、投稿ボタンを押すと投稿一覧ページに遷移すること
* 投稿一覧ページに投稿したYoutubeのサムネイル、タイトル、再生数、投稿日時、投稿者名が表示されていること
* rails consoleにてvideo及びoutputのデータが追加されていることを確認できること

close #63 