### PR TITLE
投稿詳細画面の作成

### DIFF
--- a/app/controllers/api/outputs_controller.rb
+++ b/app/controllers/api/outputs_controller.rb
@@ -1,0 +1,9 @@
+class Api::OutputsController < ApplicationController
+
+  def show
+    @outputs = Output.where(video_id: params[:id])
+    render json: @outputs.to_json(include: {user: {only: :name}})
+  end
+
+
+end

--- a/app/controllers/api/videos_controller.rb
+++ b/app/controllers/api/videos_controller.rb
@@ -10,7 +10,7 @@ class Api::VideosController < ApplicationController
 
   def index
     @videos = Video.includes(:user, :outputs)
-    render :index, formats: :json, handlers: 'jbuilder'
+    render json: @videos.to_json(include: [{user: {only: :name}}, {outputs: {include: {user: {only: :name}}}}])
   end
 
   def create
@@ -41,6 +41,11 @@ class Api::VideosController < ApplicationController
     else
       render json: @video.errors, status: :bad_request
     end
+  end
+
+  def show
+    @video = Video.where(id: params[:id])
+    render json: @video
   end
 
   private

--- a/app/controllers/api/videos_controller.rb
+++ b/app/controllers/api/videos_controller.rb
@@ -24,7 +24,7 @@ class Api::VideosController < ApplicationController
     set_yt
     yt_video = Yt::Video.new id: youtube_id
     @video = current_user.videos.build
-    @video.youtube_id = video_params[:youtube_url]
+    @video.youtube_id = youtube_id
     @video.title = yt_video.title
     @video.view_count = yt_video.view_count
     @video.published_at = yt_video.published_at

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -1,7 +1,7 @@
 <template>
   <v-app>
     <TheHeader />
-    <v-main class="grey lighten-3 accent-1">
+    <v-main class="grey lighten-4 accent-1">
       <router-view />
     </v-main>
     <TheFooter />

--- a/app/javascript/components/TheFooter.vue
+++ b/app/javascript/components/TheFooter.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-footer >
+  <v-footer color="#555555">
     <div class="ma-auto">
       <span class="ml-10">
         プライバシーポリシー

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -1,6 +1,6 @@
 <template>
   <v-app-bar
-    color="blue lighten-2"
+    color="#555555"
     dark
     app
   >

--- a/app/javascript/components/TheHeader.vue
+++ b/app/javascript/components/TheHeader.vue
@@ -35,13 +35,13 @@
     </template>
     <template v-else>
       <router-link :to="{ name: 'VideoCreate' }">
-      <v-btn
-        text
-        class="mr-5"
-      >
-        新規投稿
-      </v-btn>
-    </router-link>
+        <v-btn
+          text
+          class="mr-5"
+        >
+          新規投稿
+        </v-btn>
+      </router-link>
       <router-link
         to="#"
         @click.native="handleLogout"

--- a/app/javascript/pages/top/index.vue
+++ b/app/javascript/pages/top/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container class="cyan lighten-3 title mt-10 text-center">
+  <v-container class="main title mt-10 text-center">
     <h1 class="white--text">
       BizTubeLogger
     </h1>
@@ -29,5 +29,10 @@ export default {
 .title {
   padding-top: 130px;
   padding-bottom: 130px;
+}
+.main{
+  background: -webkit-linear-gradient(top, #D5DEE7 0%, #E8EBF2 50%, #E2E7ED 100%), -webkit-linear-gradient(top, rgba(0, 0, 0, 0.02) 50%, rgba(255, 255, 255, 0.02) 61%, rgba(0, 0, 0, 0.02) 73%), -webkit-linear-gradient(57deg, rgba(255, 255, 255, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+  background: linear-gradient(to bottom, #D5DEE7 0%, #E8EBF2 50%, #E2E7ED 100%), linear-gradient(to bottom, rgba(0, 0, 0, 0.02) 50%, rgba(255, 255, 255, 0.02) 61%, rgba(0, 0, 0, 0.02) 73%), linear-gradient(33deg, rgba(255, 255, 255, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+  background-blend-mode: normal,color-burn;
 }
 </style>

--- a/app/javascript/pages/video/create.vue
+++ b/app/javascript/pages/video/create.vue
@@ -1,49 +1,51 @@
 <template>
   <v-container class="mt-5 shades white rounded-lg mb-5">
-    <p class="text-h4 pt-5 title font-weight-bold text-center">アウトプット投稿</p>
+    <p class="text-h4 pt-5 title font-weight-bold text-center">
+      アウトプット投稿
+    </p>
 
-          <v-text-field
-            v-model="youtube_url"
-            label="YouTube動画URL"
-            placeholder="YouTube動画URLを貼り付けてください"
-            outlined
-          ></v-text-field>
+    <v-text-field
+      v-model="youtube_url"
+      label="YouTube動画URL"
+      placeholder="YouTube動画URLを貼り付けてください"
+      outlined
+    />
 
-          <v-select
-            v-model="value"
-            :items="items"
-            class="hoge"
-            chips
-            label="カテゴリー"
-            multiple
-            outlined
-          ></v-select>
+    <v-select
+      v-model="value"
+      :items="items"
+      class="hoge"
+      chips
+      label="カテゴリー"
+      multiple
+      outlined
+    />
 
-          <v-textarea
-            v-model="output.summary"
-            label="動画内容のアウトプット"
-            placeholder="動画の要約やためになった内容をまとめてみよう！"
-            auto-grow
-            outlined
-          ></v-textarea>
+    <v-textarea
+      v-model="output.summary"
+      label="動画内容のアウトプット"
+      placeholder="動画の要約やためになった内容をまとめてみよう！"
+      auto-grow
+      outlined
+    />
 
-          <v-textarea
-            v-model="output.impression"
-            label="感想、今後に活かしたいこと"
-            placeholder="動画の感想や今後に活かしたいことをまとめてみよう！"
-            auto-grow
-            outlined
-          ></v-textarea>
+    <v-textarea
+      v-model="output.impression"
+      label="感想、今後に活かしたいこと"
+      placeholder="動画の感想や今後に活かしたいことをまとめてみよう！"
+      auto-grow
+      outlined
+    />
 
 
-        <v-btn
-          class="mr-4 font-weight-bold"
-          type="submit"
-          color="success"
-          v-on:click="createVideo"
-        >
-          投稿する
-        </v-btn>
+    <v-btn
+      class="mr-4 font-weight-bold"
+      type="submit"
+      color="success"
+      @click="createVideo"
+    >
+      投稿する
+    </v-btn>
   </v-container>
 </template>
 

--- a/app/javascript/pages/video/index.vue
+++ b/app/javascript/pages/video/index.vue
@@ -9,23 +9,29 @@
         sm="4"
         md="4"
       >
+            <v-hover v-slot:default="{ hover }">
+
         <v-card
           class="mx-auto mt-4"
           max-width="350"
           height="420"
+          :elevation="hover ? 12 : 2"
         >
+        <router-link :to="{ path: `/video/${video.id}` }">
           <v-img
             :src="video.thumbnail"
             height="200px"
           />
+
           <v-card-title
-            class="font-weight-bold text-truncate d-inline-block"
+            class="text-truncate d-inline-block pt-1 pb-0"
             style="width: 100%"
           >
             {{ video.title }}
           </v-card-title>
+          </router-link>
 
-          <v-card-subtitle>
+          <v-card-subtitle class="pt-0 pb-1">
             {{ video.view_count }}回再生
           </v-card-subtitle>
 
@@ -61,6 +67,7 @@
             カテゴリー名
           </div>
         </v-card>
+            </v-hover>
       </v-col>
     </v-row>
   </v-container>
@@ -73,6 +80,7 @@ export default {
   data() {
     return {
       videos: [],
+      selected: null
     }
   },
     created() {
@@ -84,6 +92,12 @@ export default {
         .then(res => this.videos = res.data)
         .catch(err => console.log(err.status));
     },
+    showMoreInformation(video) {
+      this.$router.push({
+        name: 'VideoShow',
+        params: { id: video.id }
+      })
+    }
   }
 }
 </script>

--- a/app/javascript/pages/video/index.vue
+++ b/app/javascript/pages/video/index.vue
@@ -9,65 +9,64 @@
         sm="4"
         md="4"
       >
-            <v-hover v-slot:default="{ hover }">
-
-        <v-card
-          class="mx-auto mt-4"
-          max-width="350"
-          height="420"
-          :elevation="hover ? 12 : 2"
-        >
-        <router-link :to="{ path: `/video/${video.id}` }">
-          <v-img
-            :src="video.thumbnail"
-            height="200px"
-          />
-
-          <v-card-title
-            class="text-truncate d-inline-block pt-1 pb-0"
-            style="width: 100%"
+        <v-hover v-slot:default="{ hover }">
+          <v-card
+            class="mx-auto mt-4"
+            max-width="350"
+            height="420"
+            :elevation="hover ? 12 : 2"
           >
-            {{ video.title }}
-          </v-card-title>
-          </router-link>
+            <router-link :to="{ path: `/video/${video.id}` }">
+              <v-img
+                :src="video.thumbnail"
+                height="200px"
+              />
 
-          <v-card-subtitle class="pt-0 pb-1">
-            {{ video.view_count }}回再生
-          </v-card-subtitle>
+              <v-card-title
+                class="text-truncate d-inline-block pt-1 pb-0"
+                style="width: 100%"
+              >
+                {{ video.title }}
+              </v-card-title>
+            </router-link>
 
-          <v-card-text class="d-flex text-caption">
-            {{ video.created_at }}
-            <v-spacer />
-            <div class="mr-2">
-              <v-icon>mdi-thumb-up-outline</v-icon>
-              {{ }}
+            <v-card-subtitle class="pt-0 pb-1">
+              {{ video.view_count }}回再生
+            </v-card-subtitle>
+
+            <v-card-text class="d-flex text-caption">
+              {{ video.created_at }}
+              <v-spacer />
+              <div class="mr-2">
+                <v-icon>mdi-thumb-up-outline</v-icon>
+                {{ }}
+              </div>
+              <div>
+                <v-icon class="mr-2">
+                  mdi-comment-outline
+                </v-icon>
+                {{ }}
+              </div>
+              <div>
+                <v-icon>mdi-bookmark-outline</v-icon>
+              </div>
+            </v-card-text>
+            <div class="ml-3">
+              投稿者：
+              <span
+                v-for="output in video.outputs"
+                :key="output.id"
+                class="mr-2"
+              >
+                <v-icon>mdi-account-circle</v-icon>{{ output.user.name }}
+              </span>
             </div>
-            <div>
-              <v-icon class="mr-2">
-                mdi-comment-outline
-              </v-icon>
-              {{ }}
+            <div class="mt-3 ml-3">
+              <v-icon> mdi-tag</v-icon>
+              カテゴリー名
             </div>
-            <div>
-              <v-icon>mdi-bookmark-outline</v-icon>
-            </div>
-          </v-card-text>
-          <div class="ml-3">
-            投稿者：
-            <span
-              v-for="output in video.outputs"
-              :key="output.id"
-              class="mr-2"
-            >
-              <v-icon>mdi-account-circle</v-icon>{{ output.user.name }}
-            </span>
-          </div>
-          <div class="mt-3 ml-3">
-            <v-icon> mdi-tag</v-icon>
-            カテゴリー名
-          </div>
-        </v-card>
-            </v-hover>
+          </v-card>
+        </v-hover>
       </v-col>
     </v-row>
   </v-container>

--- a/app/javascript/pages/video/index.vue
+++ b/app/javascript/pages/video/index.vue
@@ -55,11 +55,11 @@
           <div class="ml-3">
             投稿者：
             <span
-              v-for="output in video.output_name"
+              v-for="output in video.outputs"
               :key="output.id"
               class="mr-2"
             >
-              <v-icon>mdi-account-circle</v-icon>{{ output.output_name }}
+              <v-icon>mdi-account-circle</v-icon>{{ output.user.name }}
             </span>
           </div>
           <div class="mt-3 ml-3">
@@ -83,7 +83,7 @@ export default {
       selected: null
     }
   },
-    created() {
+    mounted() {
     this.fetchVideos();
   },
   methods: {
@@ -92,12 +92,6 @@ export default {
         .then(res => this.videos = res.data)
         .catch(err => console.log(err.status));
     },
-    showMoreInformation(video) {
-      this.$router.push({
-        name: 'VideoShow',
-        params: { id: video.id }
-      })
-    }
   }
 }
 </script>

--- a/app/javascript/pages/video/show.vue
+++ b/app/javascript/pages/video/show.vue
@@ -1,27 +1,46 @@
 <template>
-<v-container>
-  <v-card class="pa-5 top-frame">
-    <div v-for="video in video"
-        :key="video.id">
-        <iframe width="840" height="473" :src="`https://www.youtube-nocookie.com/embed/${video.youtube_id}`"
-        title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-    <h4 class=" pt-5 title">{{ video.title }}</h4>
-    <div class="ml-5 pt-2">
-      <span class="count">再生回数:{{ video.view_count }}回</span>
-    </div>
-    </div>
-    <v-card class="frame pa-4 mt-3 shades rounded-lg" v-for="output in outputs" :key="output.id">
-        <h2>{{output.user.name}}さんのアウトプット投稿</h2>
-        <v-card-subtitle>投稿日{{output.created_at}}</v-card-subtitle>
-        <v-card class="box" >
+  <v-container>
+    <v-card class="pa-5 top-frame">
+      <div
+        v-for="video in video"
+        :key="video.id"
+      >
+        <iframe
+          width="840"
+          height="473"
+          :src="`https://www.youtube-nocookie.com/embed/${video.youtube_id}`"
+          title="YouTube video player"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        />
+        <h4 class=" pt-5 title">
+          {{ video.title }}
+        </h4>
+        <div class="ml-5 pt-2">
+          <span class="count">再生回数:{{ video.view_count }}回</span>
+        </div>
+      </div>
+      <v-card
+        v-for="output in outputs"
+        :key="output.id"
+        class="frame pa-4 mt-3 shades rounded-lg"
+      >
+        <h2>{{ output.user.name }}さんのアウトプット投稿</h2>
+        <v-card-subtitle>投稿日{{ output.created_at }}</v-card-subtitle>
+        <v-card class="box">
           <span class="box-title">動画内容のアウトプット</span>
-          <p class="content">{{ output.summary }}</p>
+          <p class="content">
+            {{ output.summary }}
+          </p>
         </v-card>
         <v-card class="box">
           <span class="box-title">感想や今後に活かすこと</span>
-          <p class="content">{{ output.impression }}</p>
+          <p class="content">
+            {{ output.impression }}
+          </p>
         </v-card>
-    </v-card>
+      </v-card>
     </v-card>
   </v-container>
 </template>

--- a/app/javascript/pages/video/show.vue
+++ b/app/javascript/pages/video/show.vue
@@ -1,0 +1,15 @@
+<template>
+  <div>
+    詳細ページ
+  </div>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style scoped>
+
+</style>

--- a/app/javascript/pages/video/show.vue
+++ b/app/javascript/pages/video/show.vue
@@ -1,15 +1,94 @@
 <template>
-  <div>
-    詳細ページ
-  </div>
+<v-container>
+  <v-card class="pa-5 top-frame">
+    <div v-for="video in video"
+        :key="video.id">
+        <iframe width="840" height="473" :src="`https://www.youtube-nocookie.com/embed/${video.youtube_id}`"
+        title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+    <h4 class=" pt-5 title">{{ video.title }}</h4>
+    <div class="ml-5 pt-2">
+      <span class="count">再生回数:{{ video.view_count }}回</span>
+    </div>
+    </div>
+    <v-card class="frame pa-4 mt-3 shades rounded-lg" v-for="output in outputs" :key="output.id">
+        <h2>{{output.user.name}}さんのアウトプット投稿</h2>
+        <v-card-subtitle>投稿日{{output.created_at}}</v-card-subtitle>
+        <v-card class="box" >
+          <span class="box-title">動画内容のアウトプット</span>
+          <p class="content">{{ output.summary }}</p>
+        </v-card>
+        <v-card class="box">
+          <span class="box-title">感想や今後に活かすこと</span>
+          <p class="content">{{ output.impression }}</p>
+        </v-card>
+    </v-card>
+    </v-card>
+  </v-container>
 </template>
 
 <script>
 export default {
-
+  props: ["id"],
+  data() {
+    return {
+      video: null,
+      outputs: []
+    }
+  },
+  mounted: function () {
+    this.fetchVideoDetail();
+    this.fetchOutputsDetail();
+  },
+  methods: {
+    fetchVideoDetail() {
+      this.$axios.get("/videos/" + this.id)
+        .then(res => this.video = res.data)
+        .catch(err => console.log(err.status));
+    },
+    fetchOutputsDetail() {
+      this.$axios.get("/outputs/" + this.id)
+        .then(res => this.outputs = res.data)
+        .catch(err => console.log(err.status));
+    },
+  }
 }
 </script>
 
 <style scoped>
+iframe {
+  display: block;
+  margin: 0 auto;
+  max-width: 100%;
+}
+
+.box {
+  position: relative;
+  margin: 3em 0 2em 0;
+  padding: 0.5em 1em;
+  border: solid 3px #7d420aa4;
+}
+.box .box-title {
+  position: absolute;
+  display: inline-block;
+  top: -27px;
+  left: -3px;
+  padding: 0 9px;
+  height: 25px;
+  line-height: 25px;
+  font-size: 18px;
+  background: #9999CC;
+  color: white;
+  font-weight: bold;
+  border-radius: 5px 5px 0 0;
+}
+.box p {
+  margin: 0;
+  padding: 0;
+}
+
+.top-frame{
+  background: -webkit-linear-gradient(top, #D5DEE7 0%, #E8EBF2 50%, #E2E7ED 100%), -webkit-linear-gradient(top, rgba(0, 0, 0, 0.02) 50%, rgba(255, 255, 255, 0.02) 61%, rgba(0, 0, 0, 0.02) 73%), -webkit-linear-gradient(57deg, rgba(255, 255, 255, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+  background: linear-gradient(to bottom, #D5DEE7 0%, #E8EBF2 50%, #E2E7ED 100%), linear-gradient(to bottom, rgba(0, 0, 0, 0.02) 50%, rgba(255, 255, 255, 0.02) 61%, rgba(0, 0, 0, 0.02) 73%), linear-gradient(33deg, rgba(255, 255, 255, 0.2) 0%, rgba(0, 0, 0, 0.2) 100%);
+}
 
 </style>

--- a/app/javascript/plugins/axios.js
+++ b/app/javascript/plugins/axios.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const axiosInstance = axios.create({
-  baseURL: 'api'
+  baseURL: 'http://localhost:3000/api/'
 })
 
 if (localStorage.auth_token) {

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -7,6 +7,7 @@ import RegisterIndex from "../pages/register/index"
 import LoginIndex from "../pages/login/index"
 import VideoIndex from "../pages/video/index"
 import VideoCreate from "../pages/video/create"
+import VideoShow from "../pages/video/show"
 
 Vue.use(Router)
 
@@ -38,6 +39,11 @@ const router = new Router({
       component: VideoCreate,
       name: "VideoCreate",
       meta: { requiredAuth: true },
+    },
+    {
+      path: '/video/:id',
+      name: 'VideoShow',
+      component: VideoShow
     }
   ],
 })

--- a/app/javascript/router/index.js
+++ b/app/javascript/router/index.js
@@ -43,7 +43,8 @@ const router = new Router({
     {
       path: '/video/:id',
       name: 'VideoShow',
-      component: VideoShow
+      component: VideoShow,
+      props: true
     }
   ],
 })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     resources :sessions
     resources :videos
+    resources :outputs
     resources :users, only: %i[create] do
       collection do
         get 'me'


### PR DESCRIPTION
## 概要

* 投稿一覧画面に投稿詳細画面へのルーターリンクの設置
* クリックした投稿のvideo.idを詳細画面でpropsとして受け取る
* video.idを使用し、videoとoutputのデータをaxiosで取得する。
* 詳細画面に対象のyoutube動画を表示させる。
* 詳細画面にタイトル、再生数、アウトプット投稿者名、投稿日時、要約、感想の内容を表示させる。

## 確認方法

* 一覧画面から投稿動画をクリックすると詳細表示画面に遷移すること
* 詳細画面のURLがvideo/:idとなっていること
* 表示されたYouTubeの動画を再生できること
* 詳細画面にタイトル、再生数、アウトプット投稿者名、投稿日時、要約、感想の内容が表示されていること

close #65 