### PR TITLE
本番環境でログインできないエラーを解消

### DIFF
--- a/app/models/concerns/jwt_token.rb
+++ b/app/models/concerns/jwt_token.rb
@@ -3,7 +3,7 @@ module JwtToken
 
   class_methods do
     def decode(token)
-      JWT.decode token, Rails.application.secrets.secret_key_base
+      JWT.decode token, Rails.application.credentials.secret_key_base
     end
   end
 
@@ -15,6 +15,6 @@ module JwtToken
   private
 
   def issue_token(payload)
-    JWT.encode payload, Rails.application.secrets.secret_key_base
+    JWT.encode payload, Rails.application.credentials.secret_key_base
   end
 end


### PR DESCRIPTION
## 概要

* jwtのsecretsをcredentialsに変更
* heroku config:setで本番環境にマスターキーを設定
* ログイン後、新規投稿でAPIキーmissingエラーが出たため、heroku config:setで本番環境にAPIキーを設定

## 確認方法

* 本番環境でログインできること
* 本番環境で新規投稿できること

