### PR TITLE
新規投稿画面に動画のプレビュー機能を追加

### DIFF
--- a/app/controllers/api/videopreview_controller.rb
+++ b/app/controllers/api/videopreview_controller.rb
@@ -1,0 +1,27 @@
+class Api::VideopreviewController < ApplicationController
+  GOOGLE_API_KEY = ENV.fetch('GOOGLE_API_KEY', nil)
+
+  def set_yt
+    Yt.configure do |config|
+      config.api_key = GOOGLE_API_KEY
+      config.log_level = :debug
+    end
+  end
+
+  def create
+    youtube_id = if params[:youtube_url][0..16] == 'https://youtu.be/'
+      params[:youtube_url][17..27]
+    else
+      params[:youtube_url][32..42]
+    end
+
+    set_yt
+    yt_video = Yt::Video.new id: youtube_id
+    video = Video.new
+    if video.title = yt_video.title
+      render json: youtube_id
+    else
+      render json: yt_video.errors, status: :bad_request
+    end
+  end
+end

--- a/app/javascript/pages/video/components/ShowVideo.vue
+++ b/app/javascript/pages/video/components/ShowVideo.vue
@@ -16,8 +16,9 @@
       <div class="pt-5 ml-3 mr-3 title text-h5 font-weight-bold">
         {{ video.title }}
       </div>
-      <div class="wrap-box ml-5 mb-4 pt-2">
+      <div class="d-flex ml-5 mb-4 pt-2 mr-5">
         <span class="count">再生回数:{{ video.view_count.toLocaleString() }}回</span>
+        <v-spacer />
         <span class="box-right category">
           <v-icon color="primary"> mdi-tag</v-icon>
           <v-chip
@@ -107,16 +108,4 @@ iframe {
   max-width: 100%;
 }
 
-.wrap-box {
-  position: relative;
-}
-
-.wrap-box .box-right {
-  position: absolute;
-  right: 0;
-}
-
-.category{
-  margin-right: 30px;
-}
 </style>

--- a/app/javascript/pages/video/components/VideoItem.vue
+++ b/app/javascript/pages/video/components/VideoItem.vue
@@ -34,6 +34,17 @@
             <v-card-subtitle class="pt-0 pb-1 d-flex">
               {{ video.view_count.toLocaleString() }}回再生
               <v-spacer />
+              <span>
+                <v-icon
+                  color="primary"
+                  class="mr-1"
+                >
+                  mdi-pen
+                </v-icon>
+              </span>
+              <span class="primary--text mr-1">
+                {{ video.outputs.length }}
+              </span>
               <span class="mr-1">
                 <v-icon color="primary">mdi-thumb-up-outline</v-icon>
               </span>
@@ -47,7 +58,7 @@
               <span>
                 <v-icon
                   color="primary"
-                  class="mr-1"
+                  class="mr-1 ml-1"
                 >
                   mdi-comment-outline
                 </v-icon>

--- a/app/javascript/pages/video/create.vue
+++ b/app/javascript/pages/video/create.vue
@@ -25,14 +25,37 @@
             v-slot="{ errors }"
             rules="required|url_format"
           >
+          <div class="d-flex flex-row align-baseline">
             <v-text-field
               v-model="youtube_url"
               label="YouTube動画URL"
               placeholder="YouTube動画URLを貼り付けてください"
               outlined
               :error-messages="errors"
+              class="input-url"
+              v-bind:disabled="isDisabled"
             />
+            <v-btn class="ma-2 pa-2" color="primary" @click="previewVideo" v-bind:disabled="isDisabled">
+              プレビュー
+            </v-btn>
+          </div>
           </ValidationProvider>
+
+          <div v-if="youtubeId" class="justify-center d-flex mb-5">
+          <iframe
+        width="840"
+        height="473"
+        :src="`https://www.youtube.com/embed/${youtubeId}`"
+        title="YouTube video player"
+        frameborder="0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowfullscreen
+        class="d-inline-block"
+      />
+        <div class="d-inline-block">
+          <v-icon @click="closePreviewVideo" large color="error">mdi-close-box</v-icon>
+        </div>
+      </div>
 
           <v-select
             v-model="selected_categories"
@@ -106,7 +129,9 @@ export default {
       output: {
         summary: '',
         impression: ''
-      }
+      },
+      youtubeId: '',
+      isDisabled: false
     }),
     created: function () {
       this.fetchCategories();
@@ -141,10 +166,33 @@ export default {
         .then(res => this.categories = res.data)
         .catch(err => console.log(err.status));
     },
-
+      previewVideo() {
+        this.youtubeId = ''
+        this.$axios.post('videopreview', { youtube_url: this.youtube_url})
+          .then(res => {
+            this.youtubeId = res.data
+            this.isDisabled = true
+          })
+          .catch(err => {
+            this.showMessage(
+        {
+          message: "プレビューに失敗しました",
+          type: "error",
+          status: true,
+        },
+      )
+            console.log(err)
+          })
+    },
+    closePreviewVideo(){
+      this.youtubeId = ''
+      this.isDisabled = false
     }
+
+  }
 }
 </script>
 
 <style scoped>
+
 </style>

--- a/app/javascript/pages/video/create.vue
+++ b/app/javascript/pages/video/create.vue
@@ -25,37 +25,51 @@
             v-slot="{ errors }"
             rules="required|url_format"
           >
-          <div class="d-flex flex-row align-baseline">
-            <v-text-field
-              v-model="youtube_url"
-              label="YouTube動画URL"
-              placeholder="YouTube動画URLを貼り付けてください"
-              outlined
-              :error-messages="errors"
-              class="input-url"
-              v-bind:disabled="isDisabled"
-            />
-            <v-btn class="ma-2 pa-2" color="primary" @click="previewVideo" v-bind:disabled="isDisabled">
-              プレビュー
-            </v-btn>
-          </div>
+            <div class="d-flex flex-row align-baseline">
+              <v-text-field
+                v-model="youtube_url"
+                label="YouTube動画URL"
+                placeholder="YouTube動画URLを貼り付けてください"
+                outlined
+                :error-messages="errors"
+                class="input-url"
+                :disabled="isDisabled"
+              />
+              <v-btn
+                class="ma-2 pa-2"
+                color="primary"
+                :disabled="isDisabled"
+                @click="previewVideo"
+              >
+                プレビュー
+              </v-btn>
+            </div>
           </ValidationProvider>
 
-          <div v-if="youtubeId" class="justify-center d-flex mb-5">
-          <iframe
-        width="840"
-        height="473"
-        :src="`https://www.youtube.com/embed/${youtubeId}`"
-        title="YouTube video player"
-        frameborder="0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-        allowfullscreen
-        class="d-inline-block"
-      />
-        <div class="d-inline-block">
-          <v-icon @click="closePreviewVideo" large color="error">mdi-close-box</v-icon>
-        </div>
-      </div>
+          <div
+            v-if="youtubeId"
+            class="justify-center d-flex mb-5"
+          >
+            <iframe
+              width="840"
+              height="473"
+              :src="`https://www.youtube.com/embed/${youtubeId}`"
+              title="YouTube video player"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+              class="d-inline-block"
+            />
+            <div class="d-inline-block">
+              <v-icon
+                large
+                color="error"
+                @click="closePreviewVideo"
+              >
+                mdi-close-box
+              </v-icon>
+            </div>
+          </div>
 
           <v-select
             v-model="selected_categories"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
     resources :categories
     resources :comments
     resources :profile
+    resources :videopreview
     resources :mypages do
       get :likes_comments_count, on: :collection
     end


### PR DESCRIPTION
## 概要

* videopreview_controllerの実装
* video/create.vueにプレビューボタンを設置
* video/create.vueにpreviewVideoメソッドを定義
* 一覧画面にアウトプット数の表示を追加

## 確認方法

* 新規投稿画面でURLを入力し、プレビューボタンをクリックすると動画が表示され、入力欄とプレビューボタンは制御不可になること
* プレビュー表示状態で動画右上のバツアイコンを押すとプレビューが消え、入力欄とプレビューボタンが制御可能となること
* 誤ったURLを入れてプレビューボタンをクリックすると「プレビューに失敗しました」とフラッシュメッセージが表示されること
* 一覧画面の各投稿にアウトプット数が表示されていること

close #109 