### PR TITLE
1日毎に再生回数を更新する処理を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -68,3 +68,4 @@ gem 'net-pop'
 gem 'pagy'
 gem 'config'
 gem 'meta-tags'
+gem 'whenever', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -60,7 +60,6 @@ end
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 gem 'sorcery'
-gem 'oauth2'
 gem 'jwt'
 gem 'yt', '~> 0.32.0'
 gem 'net-smtp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -373,7 +373,6 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
-  oauth2
   pagy
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,4 +401,4 @@ RUBY VERSION
    ruby 3.1.2p20
 
 BUNDLED WITH
-   2.3.7
+   2.3.23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    chronic (0.10.2)
     concurrent-ruby (1.1.10)
     config (4.0.0)
       deep_merge (~> 1.2, >= 1.2.1)
@@ -348,6 +349,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yt (0.32.6)
@@ -391,6 +394,7 @@ DEPENDENCIES
   web-console (>= 4.1.0)
   webdrivers
   webpacker (~> 5.0)
+  whenever
   yt (~> 0.32.0)
 
 RUBY VERSION

--- a/app/controllers/api/bookmarks_controller.rb
+++ b/app/controllers/api/bookmarks_controller.rb
@@ -1,5 +1,6 @@
 class Api::BookmarksController < ApplicationController
   before_action :set_video, only: %i[create destroy]
+  before_action :authenticate!, only: %i[create destroy]
 
   def index
     @bookmarks = current_user.bookmark_videos

--- a/app/controllers/api/categories_controller.rb
+++ b/app/controllers/api/categories_controller.rb
@@ -1,6 +1,6 @@
 class Api::CategoriesController < ApplicationController
   def index
-    @categories = Category.all
-    render json: @categories
+    categories = Category.all
+    render json: categories
   end
 end

--- a/app/controllers/api/comments_controller.rb
+++ b/app/controllers/api/comments_controller.rb
@@ -1,4 +1,5 @@
 class Api::CommentsController < ApplicationController
+  before_action :authenticate!
   def create
     comment = current_user.comments.build(comment_params)
     if comment.save

--- a/app/controllers/api/likes_controller.rb
+++ b/app/controllers/api/likes_controller.rb
@@ -1,5 +1,6 @@
 class Api::LikesController < ApplicationController
   before_action :set_output, only: %i[create destroy]
+  before_action :authenticate!
 
   def create
     current_user.like(@output)

--- a/app/controllers/api/mypages_controller.rb
+++ b/app/controllers/api/mypages_controller.rb
@@ -1,4 +1,5 @@
 class Api::MypagesController < ApplicationController
+  before_action :authenticate!
   def index
     @videos = Video.joins(:outputs).where(outputs: { user_id: current_user.id }).distinct.includes(:user, :outputs, :categories).order('outputs.created_at DESC')
     render :index, formats: :json, handlers: 'jbuilder'

--- a/app/controllers/api/outputs_controller.rb
+++ b/app/controllers/api/outputs_controller.rb
@@ -1,5 +1,6 @@
 class Api::OutputsController < ApplicationController
   before_action :set_output, only: %i[update destroy]
+  before_action :authenticate!, only: %i[create update destroy]
 
   def show
     @outputs = Output.where(video_id: params[:id]).includes(:user, :likes, :comments).order(created_at: :asc)

--- a/app/controllers/api/outputs_controller.rb
+++ b/app/controllers/api/outputs_controller.rb
@@ -25,6 +25,7 @@ class Api::OutputsController < ApplicationController
 
   def destroy
     @video = Video.find(@output.video_id)
+    #output投稿が1件のみの場合、videoも同時に削除
     if @video.outputs.length == 1
       @video.destroy!
       render json: [@video, @output]

--- a/app/controllers/api/profile_controller.rb
+++ b/app/controllers/api/profile_controller.rb
@@ -1,4 +1,5 @@
 class Api::ProfileController < ApplicationController
+  before_action :authenticate!
   def update
     user = User.find(current_user.id)
     if user.update(user_params)

--- a/app/controllers/api/videopreview_controller.rb
+++ b/app/controllers/api/videopreview_controller.rb
@@ -1,4 +1,5 @@
 class Api::VideopreviewController < ApplicationController
+  before_action :authenticate!
   GOOGLE_API_KEY = ENV.fetch('GOOGLE_API_KEY', nil)
 
   def set_yt

--- a/app/controllers/api/videos_controller.rb
+++ b/app/controllers/api/videos_controller.rb
@@ -1,4 +1,5 @@
 class Api::VideosController < ApplicationController
+  before_action :authenticate!, only: %i[create]
   include Pagy::Backend
 
   def index

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -21,6 +21,8 @@
 
 # Rails.rootを使用するために必要
 require File.expand_path(File.dirname(__FILE__) + '/environment')
+# PATHの設定
+job_type :rake, "export PATH=\"$HOME/.rbenv/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
 # cronを実行する環境変数(RAILS_ENVが指定されていないときはdevelopmentを使用)
 rails_env = ENV['RAILS_ENV'] || :development
 # cronを実行する環境変数をセット（上記で作成した変数を指定）

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -31,6 +31,6 @@ set :environment, rails_env
 # cronのログファイルの出力先指定
 set :output, "#{Rails.root}/log/cron.log"
 
-every :minute do
+every 1.day, at: '9:00 am' do
   rake 'view_count:update_view_count'
 end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,33 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+# Rails.rootを使用するために必要
+require File.expand_path(File.dirname(__FILE__) + '/environment')
+# cronを実行する環境変数(RAILS_ENVが指定されていないときはdevelopmentを使用)
+rails_env = ENV['RAILS_ENV'] || :development
+# cronを実行する環境変数をセット（上記で作成した変数を指定）
+set :environment, rails_env
+# cronのログファイルの出力先指定
+set :output, "#{Rails.root}/log/cron.log"
+
+every :day do
+  rake 'view_count:update_view_count'
+end

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -22,7 +22,8 @@
 # Rails.rootを使用するために必要
 require File.expand_path(File.dirname(__FILE__) + '/environment')
 # PATHの設定
-job_type :rake, "export PATH=\"$HOME/.rbenv/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
+set :job_template, "/bin/zsh -l -c ':job'"
+job_type :rake, "source /Users/ryo/.zshrc; export PATH=\"$HOME/.rbenv/bin:$PATH\"; eval \"$(rbenv init -)\"; cd :path && RAILS_ENV=:environment bundle exec rake :task :output"
 # cronを実行する環境変数(RAILS_ENVが指定されていないときはdevelopmentを使用)
 rails_env = ENV['RAILS_ENV'] || :development
 # cronを実行する環境変数をセット（上記で作成した変数を指定）
@@ -30,6 +31,6 @@ set :environment, rails_env
 # cronのログファイルの出力先指定
 set :output, "#{Rails.root}/log/cron.log"
 
-every :day do
+every :minute do
   rake 'view_count:update_view_count'
 end

--- a/lib/tasks/view_count.rake
+++ b/lib/tasks/view_count.rake
@@ -1,0 +1,19 @@
+namespace :view_count do
+  desc 'Videoの再生回数を更新する'
+  task update_view_count: :environment do
+    GOOGLE_API_KEY = ENV.fetch('GOOGLE_API_KEY', nil)
+    def set_yt
+      Yt.configure do |config|
+        config.api_key = GOOGLE_API_KEY
+        config.log_level = :debug
+      end
+    end
+    @video = Video.all
+    @video.each do |video|
+      set_yt
+      yt_video = Yt::Video.new id: video.youtube_id
+      video.view_count = yt_video.view_count
+      video.save!
+    end
+  end
+end


### PR DESCRIPTION
## 概要

* ログインが必要なコントローラーアクションにbefore_action:authenticate!を追加
* 再生回数を更新するraketaskの作成
* gem wheneverの導入
* schedule.rbに設定を記載
* 本番環境ではwheneverが機能しなかったため、herokuのアドオン「Heroku Scheduler」に設定を記述

## 確認方法

* bundle exec rails view_count:update_view_count コマンドで再生回数が更新されること
* 指定した時刻に更新処理が実施されていること
