### PR TITLE
Fix:パスワードのバリデーションの修正

### DIFF
--- a/app/javascript/pages/login/index.vue
+++ b/app/javascript/pages/login/index.vue
@@ -38,7 +38,7 @@
             <ValidationProvider
               v-slot="{ errors }"
               name="パスワード"
-              rules="required|min:3"
+              rules="required"
             >
               <v-text-field
                 v-model="user.password"

--- a/app/javascript/pages/register/index.vue
+++ b/app/javascript/pages/register/index.vue
@@ -49,7 +49,7 @@
             </ValidationProvider>
             <ValidationProvider
               v-slot="{ errors }"
-              rules="required|min:3"
+              rules="required|min:6"
               vid="password"
               name="パスワード"
             >
@@ -66,7 +66,7 @@
             <ValidationProvider
               v-slot="{ errors }"
               name="パスワード(確認)"
-              rules="required|min:3|password_confirmed:@password"
+              rules="required|min:6|password_confirmed:@password"
             >
               <v-text-field
                 v-model="user.password_confirmation"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,7 @@ class User < ApplicationRecord
   has_many :likes, dependent: :destroy
   has_many :like_outputs, through: :likes, source: :output
 
-  validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }
+  validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }
 


### PR DESCRIPTION
## 概要

* ユーザー新規登録時のパスワードのバリデーションを3文字から6文字に変更

## 確認方法

* ユーザー登録画面で6文字以上でしか登録できないこと
* これまでに登録されていた3文字以上のパスワードでもログインできること